### PR TITLE
Fix bug in Markdown reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,8 @@ install:
   - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # Optional dependencies.
-  - conda install pip tornado
   # TODO: IPython 2 env as well
-  # IPython 3.0.beta
-  - pip install --pre 'ipython'
-  - pip install jsonschema
+  - conda install pip tornado ipython
   # Testing dependencies.
   - conda install pytest flake8 coverage
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - source activate testenv
   # Optional dependencies.
   # TODO: IPython 2 env as well
-  - conda install pip tornado ipython
+  - conda install pip ipython-notebook
   # Testing dependencies.
   - conda install pytest flake8 coverage
   - pip install coveralls

--- a/ipymd/formats/markdown.py
+++ b/ipymd/formats/markdown.py
@@ -164,6 +164,8 @@ class MarkdownReader(BaseMarkdownReader):
 
     def _has_input_prompt(self, lines):
         """Return whether the line or set of lines has an input prompt."""
+        # Note: the rstrip() is necessary for empty lines with the
+        # leading '...' prompt but not the trailing space. See PR #25.
         if isinstance(lines, list):
             return any(line for line in lines
                        if line.startswith(self.prompt_first.rstrip()))

--- a/ipymd/formats/markdown.py
+++ b/ipymd/formats/markdown.py
@@ -166,10 +166,10 @@ class MarkdownReader(BaseMarkdownReader):
         """Return whether the line or set of lines has an input prompt."""
         if isinstance(lines, list):
             return any(line for line in lines
-                       if line.startswith(self.prompt_first))
+                       if line.startswith(self.prompt_first.rstrip()))
         else:
-            return (lines.startswith(self.prompt_first) or
-                    lines.startswith(self.prompt_next))
+            return lines.startswith((self.prompt_first.rstrip(),
+                                     self.prompt_next.rstrip()))
 
     def _remove_prompt(self, line):
         """Remove the prompt in a line."""

--- a/ipymd/formats/tests/test_markdown.py
+++ b/ipymd/formats/tests/test_markdown.py
@@ -54,7 +54,7 @@ def test_markdown_markdown():
 
 
 def test_decorator():
-
+    """Test a bug fix where empty '...' lines were added to the output."""
     markdown = '\n'.join(('```python',
                           '>>> @decorator',
                           '... def f():',

--- a/ipymd/formats/tests/test_markdown.py
+++ b/ipymd/formats/tests/test_markdown.py
@@ -51,3 +51,23 @@ def test_markdown_writer():
 def test_markdown_markdown():
     _test_markdown_markdown('ex1')
     _test_markdown_markdown('ex2')
+
+
+def test_decorator():
+
+    source = "\n".join(("@decorator",
+                        "def f():",
+                        "    # pass",
+                        "    ",
+                        "    return",
+                        ))
+    cells = [{'cell_type': 'code',
+              'input': source,
+              'output': 'blah\nblah'}]
+    markdown = convert(cells, to='markdown')
+    cells_bis = convert(markdown, from_='markdown')
+    markdown_bis = convert(cells_bis, to='markdown')
+
+    print("***")
+    print(markdown_bis)
+    print("***")

--- a/ipymd/formats/tests/test_markdown.py
+++ b/ipymd/formats/tests/test_markdown.py
@@ -55,19 +55,20 @@ def test_markdown_markdown():
 
 def test_decorator():
 
-    source = "\n".join(("@decorator",
-                        "def f():",
-                        "    # pass",
-                        "    ",
-                        "    return",
-                        ))
-    cells = [{'cell_type': 'code',
-              'input': source,
-              'output': 'blah\nblah'}]
-    markdown = convert(cells, to='markdown')
-    cells_bis = convert(markdown, from_='markdown')
-    markdown_bis = convert(cells_bis, to='markdown')
+    markdown = '\n'.join(('```python',
+                          '>>> @decorator',
+                          '... def f():',
+                          '...     """Docstring."""',
+                          '...',
+                          '...     # Comment.',
+                          '...     pass',
+                          '...',
+                          '...     # Comment.',
+                          '...     pass',
+                          '...     pass',
+                          'blah',
+                          'blah',
+                          '```'))
 
-    print("***")
-    print(markdown_bis)
-    print("***")
+    cells = convert(markdown, from_='markdown')
+    assert cells[0]['output'] == 'blah\nblah'


### PR DESCRIPTION
This bug occured when there were empty code lines prefixed by the `...` prompt *without the trailing space*. In this case there were extra `...` output lines in the converted cell.

A new test case checks that this bug doesn't reappear.

This PR also updates travis to latest stable IPython.