### PR TITLE
Add new Python format

### DIFF
--- a/examples/ex1.python.py
+++ b/examples/ex1.python.py
@@ -1,0 +1,13 @@
+# # Header
+
+# A paragraph.
+
+# Python code:
+
+print("Hello world!")
+
+# JavaScript code:
+
+# ```javascript
+# console.log("Hello world!");
+# ```

--- a/examples/ex2.python.py
+++ b/examples/ex2.python.py
@@ -1,0 +1,72 @@
+# # Test notebook
+
+# This is a text notebook. Here _are_ some **rich text**, `code`, $\pi\simeq 3.1415$ equations.
+
+# Another equation:
+
+# $$\sum_{i=1}^n x_i$$
+
+# Python code:
+
+# some code in python
+def f(x):
+    y = x * x
+    return y
+
+# Random code:
+
+# ```javascript
+# console.log("hello" + 3);
+# ```
+
+# Python code:
+
+import IPython
+print("Hello world!")
+
+2*2
+
+def decorator(f):
+    return f
+
+@decorator
+def f(x):
+    pass
+3*3
+
+# some text
+
+print(4*4)
+
+%%bash
+echo 'hello'
+
+# An image:
+
+# ![Hello world](http://wristgeek.com/wp-content/uploads/2014/09/hello_world.png)
+
+# ### Subtitle
+
+# a list
+
+# * One [small](http://www.google.fr) link!
+# * Two
+#     * 2.1
+#     * 2.2
+# * Three
+
+# and
+
+# 1. Un
+# 2. Deux
+
+import numpy as np
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+plt.imshow(np.random.rand(5,5,4), interpolation='none');
+
+# > TIP (a block quote): That's all folks.
+# > Last line.
+
+# Last paragraph.

--- a/ipymd/formats/__init__.py
+++ b/ipymd/formats/__init__.py
@@ -5,3 +5,4 @@ import os.path as op
 from .notebook import *
 from .markdown import *
 from .atlas import *
+from .python import *

--- a/ipymd/formats/markdown.py
+++ b/ipymd/formats/markdown.py
@@ -14,21 +14,12 @@ import re
 from collections import OrderedDict
 
 from ..six import StringIO
-from ..utils import _ensure_string
+from ..utils import _ensure_string, _preprocess
 
 
 #------------------------------------------------------------------------------
 # Base Markdown
 #------------------------------------------------------------------------------
-
-def _preprocess(text, tab=4):
-    text = re.sub(r'\r\n|\r', '\n', text)
-    text = text.replace('\t', ' ' * tab)
-    text = text.replace('\u00a0', ' ')
-    text = text.replace('\u2424', '\n')
-    pattern = re.compile(r'^ +$', re.M)
-    return pattern.sub('', text)
-
 
 _tag = (
     r'(?!(?:'

--- a/ipymd/formats/python.py
+++ b/ipymd/formats/python.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+"""Python reader and writer."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+import re
+from collections import OrderedDict
+
+from ..six import StringIO
+from ..utils import _ensure_string, _preprocess
+
+
+#------------------------------------------------------------------------------
+# Python reader and writer
+#------------------------------------------------------------------------------
+
+def _split_python(python):
+    """Split Python source into chunks.
+
+    Chunks are separated by at least two return lines. The break must not
+    be followed by a space.
+
+    """
+    python = _preprocess(python)
+    cells = re.split(r'[\n]{2,}(?=[^ ])', python)
+    return cells
+
+
+def _is_chunk_comment(source):
+    """Return whether a chunk is a comment."""
+    return all(line.startswith('# ') for line in source.splitlines())
+
+
+def _remove_hash(source):
+    """Remove the leading '#' of every line in the source."""
+    return '\n'.join(line[2:].rstrip() for line in source.splitlines())
+
+
+def _add_hash(source):
+    """Add a leading hash '#' at the beginning of every line in the source."""
+    source = '\n'.join('# ' + line.rstrip()
+                       for line in source.splitlines())
+    return source
+
+
+class PythonReader(object):
+    """Python reader."""
+    def read(self, python):
+        chunks = _split_python(python)
+        for chunk in chunks:
+            if _is_chunk_comment(chunk):
+                yield self._markdown_cell(_remove_hash(chunk))
+            else:
+                yield self._code_cell(chunk)
+
+    def _code_cell(self, source):
+        return {'cell_type': 'code',
+                'input': source,
+                'output': None}
+
+    def _markdown_cell(self, source):
+        return {'cell_type': 'markdown',
+                'source': source}
+
+
+class PythonWriter(object):
+    """Python writer."""
+
+    def __init__(self):
+        self._output = StringIO()
+
+    def _new_paragraph(self):
+        self._output.write('\n\n')
+
+    def append_comments(self, source):
+        comments = source.rstrip()
+        comments = _add_hash(comments)
+        self._output.write(comments)
+
+    def append_code(self, input):
+        self._output.write(input)
+
+    def write(self, cell):
+        if cell['cell_type'] == 'markdown':
+            self.append_comments(cell['source'])
+        elif cell['cell_type'] == 'code':
+            self.append_code(cell['input'])
+        self._new_paragraph()
+
+    @property
+    def contents(self):
+        return self._output.getvalue().rstrip() + '\n'  # end of file \n
+
+    def close(self):
+        self._output.close()
+
+    def __del__(self):
+        self.close()
+
+
+PYTHON_FORMAT = dict(
+    name='python',
+    reader=PythonReader,
+    writer=PythonWriter,
+    file_extension='.py',
+    file_type='text',
+)

--- a/ipymd/formats/tests/test_atlas.py
+++ b/ipymd/formats/tests/test_atlas.py
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------
 
 from ...core import format_manager, convert
+from ...utils import _remove_output
 from ._utils import (_test_reader, _test_writer, _diff, _show_outputs,
                      _exec_test_file, _read_test_file)
 
@@ -21,15 +22,7 @@ def _test_atlas_reader(basename):
 
     # Assert all cells are identical except the outputs which are lost
     # in translation.
-    for cell_0, cell_1 in zip(converted, expected):
-        assert cell_0['cell_type'] == cell_1['cell_type']
-        ct = cell_0['cell_type']
-        if ct == 'code':
-            assert cell_0['input'] == cell_1['input']
-        elif ct == 'markdown':
-            assert cell_0['source'] == cell_1['source']
-        else:
-            raise RuntimeError()
+    assert _remove_output(converted) == _remove_output(expected)
 
 
 def _test_atlas_writer(basename):

--- a/ipymd/formats/tests/test_python.py
+++ b/ipymd/formats/tests/test_python.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+"""Test Python parser and reader."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+from ...core import format_manager, convert
+from ...utils import _remove_output
+from ._utils import (_test_reader, _test_writer, _diff, _show_outputs,
+                     _exec_test_file, _read_test_file)
+
+
+#------------------------------------------------------------------------------
+# Test Python parser
+#------------------------------------------------------------------------------
+
+def _test_python_reader(basename):
+    """Check that (test cells) and (test contents ==> cells) are the same."""
+    converted, expected = _test_reader(basename, 'python')
+    assert _remove_output(converted) == _remove_output(expected)
+
+
+def _test_python_writer(basename):
+    """Check that (test contents) and (test cells ==> contents) are the same.
+    """
+    converted, expected = _test_writer(basename, 'python')
+    assert _diff(converted, expected) == ''
+
+
+def _test_python_python(basename):
+    """Check that the double conversion is the identity."""
+
+    contents = _read_test_file(basename, 'python')
+    cells = convert(contents, from_='python')
+    converted = convert(cells, to='python')
+
+    assert _diff(contents, converted) == ''
+
+
+def test_python_reader():
+    _test_python_reader('ex1')
+    _test_python_reader('ex2')
+
+
+def test_python_writer():
+    _test_python_writer('ex1')
+    _test_python_writer('ex2')
+
+
+def test_python_python():
+    _test_python_python('ex1')
+    _test_python_python('ex2')

--- a/ipymd/utils.py
+++ b/ipymd/utils.py
@@ -8,6 +8,7 @@
 
 import os
 import os.path as op
+import re
 import json
 
 from .six import exec_, string_types
@@ -17,12 +18,29 @@ from .six import exec_, string_types
 # Utils
 #------------------------------------------------------------------------------
 
+def _rstrip_lines(source):
+    if not isinstance(source, list):
+        source = source.splitlines()
+    return '\n'.join(line.rstrip() for line in source)
+
+
 def _ensure_string(source):
     """Ensure a source is a string."""
     if isinstance(source, string_types):
         return source.rstrip()
     else:
-        return '\n'.join([line.rstrip() for line in source]).rstrip()
+        return _rstrip_lines(source)
+
+
+def _preprocess(text, tab=4):
+    text = re.sub(r'\r\n|\r', '\n', text)
+    text = text.replace('\t', ' ' * tab)
+    text = text.replace('\u00a0', ' ')
+    text = text.replace('\u2424', '\n')
+    pattern = re.compile(r'^ +$', re.M)
+    text = pattern.sub('', text)
+    text = _rstrip_lines(text)
+    return text
 
 
 #------------------------------------------------------------------------------

--- a/ipymd/utils.py
+++ b/ipymd/utils.py
@@ -33,6 +33,7 @@ def _ensure_string(source):
 
 
 def _preprocess(text, tab=4):
+    """Normalize a text."""
     text = re.sub(r'\r\n|\r', '\n', text)
     text = text.replace('\t', ' ' * tab)
     text = text.replace('\u00a0', ' ')
@@ -41,6 +42,19 @@ def _preprocess(text, tab=4):
     text = pattern.sub('', text)
     text = _rstrip_lines(text)
     return text
+
+
+def _remove_output_cell(cell):
+    """Remove the output of an ipymd cell."""
+    cell = cell.copy()
+    if cell['cell_type'] == 'code':
+        cell['output'] = None
+    return cell
+
+
+def _remove_output(cells):
+    """Remove all code outputs from a list of ipymd cells."""
+    return [_remove_output_cell(cell) for cell in cells]
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This new format allows one to edit regular Python `.py` scripts directly in the notebook.

* By convention, a code cell is delimited by a double line break not followed by a space.
* Markdown cells are saved in comments

![image](https://cloud.githubusercontent.com/assets/1942359/6493689/a92e01c6-c2bc-11e4-9f4a-5e379d89861f.png)


Closes #19.

TODO later: add more configurable options

* Store output or not
* Store markdown or not
* Wrap markdown cells in `'''{contents}'''` instead of comments