### PR TITLE
Markdown filter

### DIFF
--- a/ipymd/formats/notebook.py
+++ b/ipymd/formats/notebook.py
@@ -90,6 +90,8 @@ class NotebookWriter(object):
     def append_markdown(self, source):
         # Filter Markdown contents.
         source = self._markdown_filter(source)
+        if not source:
+            return
         self._nb['cells'].append(nbf.v4.new_markdown_cell(source))
 
     def append_code(self, input, output=None, image=None):

--- a/ipymd/formats/notebook.py
+++ b/ipymd/formats/notebook.py
@@ -10,6 +10,7 @@ import json
 
 import IPython.nbformat as nbf
 
+from ..lib.markdown import MarkdownFilter
 from ..ext.six import string_types
 from ..utils.utils import _ensure_string
 
@@ -81,11 +82,14 @@ class NotebookReader(object):
 #------------------------------------------------------------------------------
 
 class NotebookWriter(object):
-    def __init__(self):
+    def __init__(self, keep_markdown=None):
         self._nb = nbf.v4.new_notebook()
         self._count = 1
+        self._markdown_filter = MarkdownFilter(keep_markdown)
 
     def append_markdown(self, source):
+        # Filter Markdown contents.
+        source = self._markdown_filter(source)
         self._nb['cells'].append(nbf.v4.new_markdown_cell(source))
 
     def append_code(self, input, output=None, image=None):

--- a/ipymd/formats/notebook.py
+++ b/ipymd/formats/notebook.py
@@ -12,6 +12,7 @@ import IPython.nbformat as nbf
 from IPython.nbformat.v4.nbbase import validate
 
 from ..lib.markdown import MarkdownFilter
+from ..lib.python import PythonFilter
 from ..ext.six import string_types
 from ..utils.utils import _ensure_string
 
@@ -83,10 +84,11 @@ class NotebookReader(object):
 #------------------------------------------------------------------------------
 
 class NotebookWriter(object):
-    def __init__(self, keep_markdown=None):
+    def __init__(self, keep_markdown=None, ipymd_skip=False):
         self._nb = nbf.v4.new_notebook()
         self._count = 1
         self._markdown_filter = MarkdownFilter(keep_markdown)
+        self._code_filter = PythonFilter(ipymd_skip=ipymd_skip)
 
     def append_markdown(self, source):
         # Filter Markdown contents.
@@ -96,6 +98,7 @@ class NotebookWriter(object):
         self._nb['cells'].append(nbf.v4.new_markdown_cell(source))
 
     def append_code(self, input, output=None, image=None):
+        input = self._code_filter(input)
         cell = nbf.v4.new_code_cell(input, execution_count=self._count)
         if output:
             cell.outputs.append(nbf.v4.new_output('execute_result',

--- a/ipymd/formats/notebook.py
+++ b/ipymd/formats/notebook.py
@@ -9,6 +9,7 @@
 import json
 
 import IPython.nbformat as nbf
+from IPython.nbformat.v4.nbbase import validate
 
 from ..lib.markdown import MarkdownFilter
 from ..ext.six import string_types
@@ -95,7 +96,7 @@ class NotebookWriter(object):
         self._nb['cells'].append(nbf.v4.new_markdown_cell(source))
 
     def append_code(self, input, output=None, image=None):
-        cell = nbf.v4.new_code_cell(input)
+        cell = nbf.v4.new_code_cell(input, execution_count=self._count)
         if output:
             cell.outputs.append(nbf.v4.new_output('execute_result',
                                 {'text/plain': output},
@@ -116,6 +117,7 @@ class NotebookWriter(object):
 
     @property
     def contents(self):
+        validate(self._nb)
         return self._nb
 
 

--- a/ipymd/formats/python.py
+++ b/ipymd/formats/python.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 
 from ..lib.base_lexer import BaseGrammar, BaseLexer
 from ..lib.markdown import MarkdownFilter
+from ..lib.python import _is_python
 from ..ext.six import StringIO
 from ..utils.utils import _ensure_string, _preprocess
 
@@ -109,11 +110,7 @@ def _is_chunk_markdown(source):
             return True
         # Try to parse the chunk: if it fails, it is Markdown, otherwise,
         # it is Python.
-        try:
-            ast.parse(source)
-            return False
-        except SyntaxError:
-            return True
+        return not _is_python(source)
     return False
 
 

--- a/ipymd/formats/python.py
+++ b/ipymd/formats/python.py
@@ -151,7 +151,7 @@ class PythonReader(object):
 
 class PythonWriter(object):
     """Python writer."""
-    def __init__(self, keep_markdown='all'):
+    def __init__(self, keep_markdown=None):
         self._output = StringIO()
         self._markdown_filter = MarkdownFilter(keep_markdown)
 

--- a/ipymd/formats/python.py
+++ b/ipymd/formats/python.py
@@ -11,6 +11,7 @@ import ast
 from collections import OrderedDict
 
 from ..lib.base_lexer import BaseGrammar, BaseLexer
+from ..lib.markdown import MarkdownFilter
 from ..ext.six import StringIO
 from ..utils.utils import _ensure_string, _preprocess
 
@@ -128,25 +129,6 @@ def _add_hash(source):
     return source
 
 
-def _replace_header_filter(filter):
-    return {'h1': '# ',
-            'h2': '## ',
-            'h3': '### ',
-            'h4': '#### ',
-            'h5': '##### ',
-            'h6': '###### ',
-            }[filter]
-
-
-def _filter_markdown(source, filters):
-    """Only keep some Markdown headers from a Markdown string."""
-    lines = source.splitlines()
-    # Filters is a list of 'hN' strings where 1 <= N <= 6.
-    headers = [_replace_header_filter(filter) for filter in filters]
-    lines = [line for line in lines if line.startswith(tuple(headers))]
-    return '\n'.join(lines)
-
-
 class PythonReader(object):
     """Python reader."""
     def read(self, python):
@@ -168,45 +150,21 @@ class PythonReader(object):
 
 
 class PythonWriter(object):
-    """Python writer.
-
-    Parameters
-    ----------
-
-    keep_markdown : str | None or False
-        What to keep from Markdown cells. Can be:
-
-        * None or False: don't keep Markdown contents
-        * 'all': keep all Markdown contents
-        * 'headers': just keep Markdown headers
-        * 'h1,h3': just keep headers of level 1 and 3 (can be any combination)
-
-    """
-
+    """Python writer."""
     def __init__(self, keep_markdown='all'):
         self._output = StringIO()
-        if keep_markdown == 'headers':
-            keep_markdown = 'h1,h2,h3,h4,h5,h6'
-        self._keep_markdown = keep_markdown
+        self._markdown_filter = MarkdownFilter(keep_markdown)
 
     def _new_paragraph(self):
         self._output.write('\n\n')
 
     def append_comments(self, source):
         source = source.rstrip()
-
-        # Skip Markdown cell.
-        if not self._keep_markdown:
-            return
-        # Only keep some Markdown headers if keep_markdown is not 'all'.
-        elif self._keep_markdown != 'all':
-            to_keep = self._keep_markdown.split(',')
-            source = _filter_markdown(source, to_keep)
-
+        # Filter Markdown contents.
+        source = self._markdown_filter(source)
         # Skip empty cells.
         if not source:
             return
-
         comments = _add_hash(source)
         self._output.write(comments)
         self._new_paragraph()

--- a/ipymd/lib/markdown.py
+++ b/ipymd/lib/markdown.py
@@ -650,7 +650,9 @@ class MarkdownFilter(object):
         * 'h1,h3': just keep headers of level 1 and 3 (can be any combination)
 
     """
-    def __init__(self, keep):
+    def __init__(self, keep=None):
+        if keep is None:
+            keep = 'all'
         if keep == 'headers':
             keep = 'h1,h2,h3,h4,h5,h6'
         if isinstance(keep, string_types) and keep != 'all':

--- a/ipymd/lib/python.py
+++ b/ipymd/lib/python.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+"""Python utility functions."""
+
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+
+import ast
+
+from ..ext.six import string_types
+
+
+# -----------------------------------------------------------------------------
+# Utility functions
+# -----------------------------------------------------------------------------
+
+def _is_python(source):
+    """Return whether a string contains valid Python code."""
+    try:
+        ast.parse(source)
+        return True
+    except SyntaxError:
+        return False
+
+
+class PythonFilter(object):
+    def __init__(self):
+        pass
+
+    def filter(self, code):
+        return '\n'.join(line for line in code.splitlines()
+                         if 'ipymd-skip' not in line)
+
+    def __call__(self, code):
+        return self.filter(code)

--- a/ipymd/lib/python.py
+++ b/ipymd/lib/python.py
@@ -26,12 +26,16 @@ def _is_python(source):
 
 
 class PythonFilter(object):
-    def __init__(self):
-        pass
+    def __init__(self, ipymd_skip=None):
+        self._ipymd_skip = ipymd_skip
 
     def filter(self, code):
-        return '\n'.join(line for line in code.splitlines()
-                         if 'ipymd-skip' not in line)
+        code = code.rstrip()
+        if self._ipymd_skip:
+            return '\n'.join(line for line in code.splitlines()
+                             if 'ipymd-skip' not in line)
+        else:
+            return code
 
     def __call__(self, code):
         return self.filter(code)

--- a/ipymd/lib/tests/test_python.py
+++ b/ipymd/lib/tests/test_python.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""Test Python routines."""
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+
+from ..python import _is_python, PythonFilter
+
+
+# -----------------------------------------------------------------------------
+# Test Python
+# -----------------------------------------------------------------------------
+
+def test_python():
+    assert _is_python("print('Hello world!')")
+    assert not _is_python("Hello world!")
+
+
+def test_python_filter():
+    filter = PythonFilter()
+    assert filter('a\nb # ipymd-skip\nc\n') == 'a\nc'

--- a/ipymd/lib/tests/test_python.py
+++ b/ipymd/lib/tests/test_python.py
@@ -20,4 +20,7 @@ def test_python():
 
 def test_python_filter():
     filter = PythonFilter()
+    assert filter('a\nb # ipymd-skip\nc\n') == 'a\nb # ipymd-skip\nc'
+
+    filter = PythonFilter(ipymd_skip=True)
     assert filter('a\nb # ipymd-skip\nc\n') == 'a\nc'


### PR DESCRIPTION
* Refactored Markdown filter.
* Added Python filter for `ipymd-skip`.
* The filter is now used in the Python and notebook formats.