### PR TITLE
updated markdown.py to use yaml.safe_dump()

### DIFF
--- a/ipymd/formats/markdown.py
+++ b/ipymd/formats/markdown.py
@@ -128,10 +128,10 @@ class BaseMarkdownWriter(object):
                 return ''
             return '---\n\n'
 
-        meta = '{}\n'.format(yaml.dump(source,
-                                       explicit_start=True,
-                                       explicit_end=True,
-                                       default_flow_style=False))
+        meta = '{}\n'.format(yaml.safe_dump(source,
+                                            explicit_start=True,
+                                            explicit_end=True,
+                                            default_flow_style=False))
 
         if is_notebook:
             # Replace the trailing `...\n\n`


### PR DESCRIPTION
If using `ipymd` with Python 2, the YAML will be written with the prefix `!!python/unicode `  preceding every string if we use `yaml.dump(...)`. By switching to `yaml.safe_dump(...)`, we ensure that the written YAML can be loaded with `yaml.safe_load(...)`.

(Stumbled across this today when switching between machines, one of which was running `ipymd` as a Python 2 library. Editing the python in the library in my site packages to use `safe_dump()` resolved the problem.)