### PR TITLE
Fix: "NameError: name '_' is not defined" running `ipymd` from commandline

### DIFF
--- a/ipymd/core/contents_manager.py
+++ b/ipymd/core/contents_manager.py
@@ -25,6 +25,7 @@ except ImportError:
     from IPython.config.configurable import Configurable
 
 try:
+    from notebook import transutils
     from notebook.services.contents.filemanager import FileContentsManager
 except ImportError:
     from IPython.html.services.contents.filemanager import FileContentsManager


### PR DESCRIPTION
- Fix #87